### PR TITLE
Incompatible with JTS 1.12 when reading polygon json

### DIFF
--- a/src/main/java/org/wololo/jts2geojson/GeoJSONReader.java
+++ b/src/main/java/org/wololo/jts2geojson/GeoJSONReader.java
@@ -71,7 +71,8 @@ public class GeoJSONReader {
             }
             return factory.createPolygon(shell, holes);
         } else {
-            return factory.createPolygon(shell);
+            //GeometryFactory in JTS 1.12 doesn't support the method createPolygon with only one parameter
+            return factory.createPolygon(shell, null);
         }
     }
 


### PR DESCRIPTION
GeometryFactory in JTS 1.12 doesn't support the method createPolygon with only one parameter