### PR TITLE
added support for  in geometry

### DIFF
--- a/src/main/java/org/wololo/geojson/Geometry.java
+++ b/src/main/java/org/wololo/geojson/Geometry.java
@@ -3,7 +3,7 @@ package org.wololo.geojson;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
-@JsonPropertyOrder({"type", "coordinates"})
+@JsonPropertyOrder({"type", "coordinates", "bbox"})
 public abstract class Geometry extends GeoJSON {
     @JsonCreator
     public Geometry() {

--- a/src/main/java/org/wololo/geojson/LineString.java
+++ b/src/main/java/org/wololo/geojson/LineString.java
@@ -2,17 +2,33 @@ package org.wololo.geojson;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
+@JsonInclude(Include.NON_NULL)
 public class LineString extends Geometry {
     private final double[][] coordinates;
-    
+    private final double[] bbox;
+
     @JsonCreator
     public LineString(@JsonProperty("coordinates") double [][] coordinates) {
         super();
         this.coordinates = coordinates;
+        this.bbox = null;
+    }
+
+    @JsonCreator
+    public LineString(@JsonProperty("coordinates") double [][] coordinates, @JsonProperty("bbox") double [] bbox) {
+        super();
+        this.coordinates = coordinates;
+        this.bbox = bbox;
     }
 
     public double[][] getCoordinates() {
         return coordinates;
+    }
+
+    public double[] getBbox() {
+        return bbox;
     }
 }

--- a/src/main/java/org/wololo/geojson/MultiLineString.java
+++ b/src/main/java/org/wololo/geojson/MultiLineString.java
@@ -2,17 +2,33 @@ package org.wololo.geojson;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
+@JsonInclude(Include.NON_NULL)
 public class MultiLineString extends Geometry {
     private final double[][][] coordinates;
-    
+    private final double[] bbox;
+
     @JsonCreator
     public MultiLineString(@JsonProperty("coordinates") double [][][] coordinates) {
         super();
         this.coordinates = coordinates;
+        this.bbox = null;
+    }
+
+    @JsonCreator
+    public MultiLineString(@JsonProperty("coordinates") double [][][] coordinates, @JsonProperty("bbox") double [] bbox) {
+        super();
+        this.coordinates = coordinates;
+        this.bbox = bbox;
     }
 
     public double[][][] getCoordinates() {
         return coordinates;
+    }
+
+    public double[] getBbox() {
+        return bbox;
     }
 }

--- a/src/main/java/org/wololo/geojson/MultiPoint.java
+++ b/src/main/java/org/wololo/geojson/MultiPoint.java
@@ -2,17 +2,33 @@ package org.wololo.geojson;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
+@JsonInclude(Include.NON_NULL)
 public class MultiPoint extends Geometry {
     private final double[][] coordinates;
-    
+    private final double[] bbox;
+
     @JsonCreator
     public MultiPoint(@JsonProperty("coordinates") double [][] coordinates) {
         super();
         this.coordinates = coordinates;
+        this.bbox = null;
+    }
+
+    @JsonCreator
+    public MultiPoint(@JsonProperty("coordinates") double [][] coordinates, @JsonProperty("bbox") double [] bbox) {
+        super();
+        this.coordinates = coordinates;
+        this.bbox = bbox;
     }
 
     public double[][] getCoordinates() {
         return coordinates;
+    }
+
+    public double[] getBbox() {
+        return bbox;
     }
 }

--- a/src/main/java/org/wololo/geojson/MultiPolygon.java
+++ b/src/main/java/org/wololo/geojson/MultiPolygon.java
@@ -2,17 +2,26 @@ package org.wololo.geojson;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
+@JsonInclude(Include.NON_NULL)
 public class MultiPolygon extends Geometry {
     private final double[][][][] coordinates;
-    
+    private final double[] bbox;
+
     @JsonCreator
     public MultiPolygon(@JsonProperty("coordinates") double [][][][] coordinates) {
         super();
         this.coordinates = coordinates;
+        this.bbox = null;
     }
 
     public double[][][][] getCoordinates() {
         return coordinates;
+    }
+
+    public double[] getBbox() {
+        return bbox;
     }
 }

--- a/src/main/java/org/wololo/geojson/Point.java
+++ b/src/main/java/org/wololo/geojson/Point.java
@@ -2,17 +2,26 @@ package org.wololo.geojson;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
+@JsonInclude(Include.NON_NULL)
 public class Point extends Geometry {
     private final double[] coordinates;
-    
+    private final double[] bbox;
+
     @JsonCreator
     public Point(@JsonProperty("coordinates") double [] coordinates) {
         super();
         this.coordinates = coordinates;
+        this.bbox = null;
     }
 
     public double[] getCoordinates() {
         return coordinates;
+    }
+
+    public double[] getBbox() {
+        return bbox;
     }
 }

--- a/src/main/java/org/wololo/geojson/Polygon.java
+++ b/src/main/java/org/wololo/geojson/Polygon.java
@@ -2,17 +2,26 @@ package org.wololo.geojson;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
+@JsonInclude(Include.NON_NULL)
 public class Polygon extends Geometry {
     private final double[][][] coordinates;
-    
+    private final double[] bbox;
+
     @JsonCreator
     public Polygon(@JsonProperty("coordinates") double [][][] coordinates) {
         super();
         this.coordinates = coordinates;
+        this.bbox = null;
     }
 
     public double[][][] getCoordinates() {
         return coordinates;
+    }
+
+    public double[] getBbox() {
+        return bbox;
     }
 }

--- a/src/test/scala/org/wololo/jts2geojson/GeoJSONFactorySpec.scala
+++ b/src/test/scala/org/wololo/jts2geojson/GeoJSONFactorySpec.scala
@@ -14,37 +14,52 @@ class GeoJSONFactorySpec extends WordSpec {
         val properties = new HashMap[String, Object]()
         properties.put("test", 1.asInstanceOf[Object])
         val feature = new Feature(geometry, properties)
-        
+
         "be identical to programmatically created Feature" in {
           val expected = """{"type":"Feature","geometry":{"type":"Point","coordinates":[1.0,1.0]},"properties":{"test":1}}"""
-          
+
           val json = feature.toString
           assert(expected == json)
-          
+
           val geoJSON = GeoJSONFactory.create(json)
           assert(expected == geoJSON.toString)
         }
-        
+
         "be identical to programmatically created Feature with id" in {
           val feature = new Feature(1, geometry, properties)
-        
+
           val expected = """{"type":"Feature","id":1,"geometry":{"type":"Point","coordinates":[1.0,1.0]},"properties":{"test":1}}"""
 
           val json = feature.toString
           assert(expected == json)
-          
+
           val geoJSON = GeoJSONFactory.create(json)
-          
+
           assert(expected == geoJSON.toString)
         }
-        
+
         "be identical to programmatically created FeatureCollection" in {
           val expected = """{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[1.0,1.0]},"properties":{"test":1}},{"type":"Feature","geometry":{"type":"Point","coordinates":[1.0,1.0]},"properties":{"test":1}}]}"""
-          
+
           val fc = new FeatureCollection(Array(feature, feature))
           assert(expected == fc.toString)
         }
+
+        "will take care of bbox property" in {
+          val geoJSON = """{"type": "FeatureCollection", "features": [{"type": "Feature", "id": 1, "geometry": {"type": "Point", "coordinates": [-8.311419016226296, 53.894485921596285], "bbox": [-8.311419016226296, 53.894485921596285, -8.311419016226296, 53.894485921596285] }, "properties": {"FID": 335, "PLAN_REF": "151", "APP_TYPE": "RETENTION", "LOCATION": "Knockglass, Ballinameen, Co. Roscommon.", "REC_DATE": "05/01/2015", "DESCRIPT": "Of entrance to existing forest plantation for extraction of timber at various times at ", "APPSTATUS": "Application Finalised", "DEC_DATE": "20/02/2015", "DECISION": "Granted (Conditional)", "APPE_DEC": "n/a", "APPE_DAT": "n/a", "MOREINFO": "http://www.eplanning.ie/roscommoneplan/FileRefDetails.aspx?file_number=151", "WGS_LONG": "-8.31141", "WGS_LAT": "53.89448"} }] }"""
+          val json = GeoJSONFactory.create(geoJSON)
+          assert(json.isInstanceOf[FeatureCollection])
+          val fc = json.asInstanceOf[FeatureCollection]
+          assert(fc.getFeatures.nonEmpty)
+          val f = fc.getFeatures.head
+          assert(f.getGeometry != null)
+          assert(f.getGeometry.isInstanceOf[Point])
+          val point = f.getGeometry.asInstanceOf[Point]
+          assert(point.getBbox != null)
+          assert(point.getBbox.toSeq == Seq(-8.311419016226296, 53.894485921596285, -8.311419016226296, 53.894485921596285))
+        }
+
       }
-      
+
     }
 }

--- a/src/test/scala/org/wololo/jts2geojson/GeoJSONWriterSpec.scala
+++ b/src/test/scala/org/wololo/jts2geojson/GeoJSONWriterSpec.scala
@@ -9,7 +9,7 @@ import org.wololo.geojson.FeatureCollection
 class GeoJSONWriterSpec extends WordSpec {
   "GeoJSONWriter" when {
     "writing GeoJSON from JTS object" should {
-      
+
       val reader = new GeoJSONReader()
       val writer = new GeoJSONWriter()
       val factory = new GeometryFactory()
@@ -36,7 +36,7 @@ class GeoJSONWriterSpec extends WordSpec {
         val json = writer.write(lineString)
         assert("""{"type":"LineString","coordinates":[[1.0,1.0],[1.0,2.0],[2.0,2.0],[1.0,1.0]]}""" === json.toString)
       }
-      
+
       "expected result for LineString with id" in {
         val json = writer.write(lineString)
         assert("""{"type":"LineString","coordinates":[[1.0,1.0],[1.0,2.0],[2.0,2.0],[1.0,1.0]]}""" === json.toString)


### PR DESCRIPTION
Hello @bjornharrtell !

Nice lib thanks a lot, I'm using it for the geo support in my spark-notebook (https://github.com/andypetrella/spark-notebook/). So we can plot geo chart easily from scala and interactively :-).

However, I've been reported this issue https://github.com/andypetrella/spark-notebook/issues/433 by 	@jp-gorman which raised the fact that `bbox` wasn't yet supported in the geojson reader. 

So I didn't wanted to bother you too much for that, hence this PR :-).

Let me know (as soon it's released I'll update my version in the spark notebook)

cheers