### PR TITLE
Add annotations for handling Geometry subclasses in GeometryCollection

### DIFF
--- a/src/main/java/org/wololo/geojson/Geometry.java
+++ b/src/main/java/org/wololo/geojson/Geometry.java
@@ -2,6 +2,25 @@ package org.wololo.geojson;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    property = "type"
+)
+@JsonSubTypes( {
+  @JsonSubTypes.Type(value=Point.class, name="Point"  ),
+  @JsonSubTypes.Type(value=LineString.class, name="LineString"  ),
+  @JsonSubTypes.Type(value=Polygon.class, name="Polygon"  ),
+  @JsonSubTypes.Type(value=MultiPoint.class, name="MultiPoint"  ),
+  @JsonSubTypes.Type(value=MultiLineString.class, name="MultiLineString"  ),
+  @JsonSubTypes.Type(value=MultiPolygon.class, name="MultiPolygon"  ),
+  @JsonSubTypes.Type(value=Feature.class, name="Feature"  ),
+  @JsonSubTypes.Type(value=FeatureCollection.class, name="FeatureCollection"  ),
+  @JsonSubTypes.Type(value=GeometryCollection.class, name="GeometryCollection"  )
+} )
 
 @JsonPropertyOrder({"type", "coordinates", "bbox"})
 public abstract class Geometry extends GeoJSON {

--- a/src/test/scala/org/wololo/jts2geojson/DeserializeGeometryCollectionSpec.scala
+++ b/src/test/scala/org/wololo/jts2geojson/DeserializeGeometryCollectionSpec.scala
@@ -1,0 +1,33 @@
+package org.wololo.jts2geojson
+
+import java.util.HashMap
+
+import org.scalatest.WordSpec
+import org.wololo.geojson._
+
+class DeserializeGeometryCollectionSpec extends WordSpec {
+    "GeoJSONFactory" when {
+      "parsing GeoJSON to object" should {
+        val geometry = new Point(Array(1, 1))
+        val properties = new HashMap[String, Object]()
+        properties.put("test", 1.asInstanceOf[Object])
+        val feature = new Feature(geometry, properties)
+
+
+        "deserialize GeometryCollection successfully" in {
+          val geoJSON = """{"type": "GeometryCollection", "geometries": [{"type": "Point",  "coordinates": [1.1, 2.2] }]}"""
+          val json = GeoJSONFactory.create(geoJSON)
+          assert(json.isInstanceOf[GeometryCollection])
+          val gc = json.asInstanceOf[GeometryCollection]
+          assert(gc.getGeometries.nonEmpty)
+          val g = gc.getGeometries.head
+          assert(g != null)
+          assert(g.isInstanceOf[Point])
+          val point = g.asInstanceOf[Point]
+          assert(point.getCoordinates.toSeq == Seq(1.1, 2.2))
+        }
+
+      }
+
+    }
+}


### PR DESCRIPTION
This change allows GeometryCollection instances to be deserialized successfully.  Note, I've added a separate spec test class to avoid merge conflicts with a change I made for a different pull request on a separate branch.