### PR TITLE
Shave off 20 MB when including this project through Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,11 +50,13 @@
 			<groupId>org.scalatest</groupId>
 			<artifactId>scalatest_2.11</artifactId>
 			<version>3.0.0</version>
+                        <scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.scalactic</groupId>
 			<artifactId>scalactic_2.11</artifactId>
 			<version>3.0.0</version>
+                        <scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.vividsolutions</groupId>


### PR DESCRIPTION
I include jts2geojson in my own project as a Maven dependency. As far as I can see, the Scala dependencies are for testing only. By tagging them as such in pom.xml my project shaves off 20+ MB