### PR TITLE
GeoJSONFactory now supports parsing features with null geometries

### DIFF
--- a/src/main/java/org/wololo/geojson/GeoJSONFactory.java
+++ b/src/main/java/org/wololo/geojson/GeoJSONFactory.java
@@ -50,14 +50,23 @@ public class GeoJSONFactory {
         JavaType javaType = mapper.getTypeFactory().constructMapType(Map.class, String.class, Object.class);
         Object id = node.get("id");
         Map<String, Object> properties = mapper.readValue(node.get("properties").traverse(), javaType);
-        String type = geometryNode.get("type").asText();
-        Geometry geometry = readGeometry(geometryNode, type);
+        Geometry geometry = readGeometry(geometryNode);
         return new Feature(id, geometry, properties);
     }
     
+    private static Geometry readGeometry(JsonNode node)
+            throws JsonParseException, JsonMappingException, IOException, ClassNotFoundException {
+        if (!node.isNull()) {
+            final String type = node.get("type").asText();
+            return readGeometry(node, type);
+        } else {
+            return null;
+        }
+    }
+
     private static Geometry readGeometry(JsonNode node, String type)
             throws JsonParseException, JsonMappingException, IOException, ClassNotFoundException {
-        Geometry geometry = (Geometry) mapper.readValue(node.traverse(), Class.forName("org.wololo.geojson." + type));
-        return geometry;
+        return (Geometry) mapper.readValue(node.traverse(), Class.forName("org.wololo.geojson." + type));
     }
+
 }

--- a/src/test/scala/org/wololo/jts2geojson/GeoJSONFactorySpec.scala
+++ b/src/test/scala/org/wololo/jts2geojson/GeoJSONFactorySpec.scala
@@ -35,6 +35,19 @@ class GeoJSONFactorySpec extends WordSpec {
           assert(expected == geoJSON.toString)
         }
 
+        "be identical to programmatically created Feature without geometry" in {
+          val feature = new Feature(null, properties)
+
+          val expected = """{"type":"Feature","geometry":null,"properties":{"test":1}}"""
+
+          val json = feature.toString
+          assert(expected == json)
+
+          val geoJSON = GeoJSONFactory.create(json)
+
+          assert(expected == geoJSON.toString)
+        }
+
         "be identical to programmatically created FeatureCollection" in {
           val expected = """{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[1.0,1.0]},"properties":{"test":1}},{"type":"Feature","geometry":{"type":"Point","coordinates":[1.0,1.0]},"properties":{"test":1}}]}"""
 


### PR DESCRIPTION
This PR addresses [Issue#20](https://github.com/bjornharrtell/jts2geojson/issues/20)

Features with null geometries can be deserialized successfully.
GeoJSON with no "type" at the top level still retain existing behaviour
of throwing a NullPointerException when parsed.


