### PR TITLE
Add option to configure support for custom ObjectMapper's

### DIFF
--- a/src/main/java/org/wololo/geojson/GeoJSON.java
+++ b/src/main/java/org/wololo/geojson/GeoJSON.java
@@ -9,8 +9,6 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public abstract class GeoJSON {
-    private static final ObjectMapper mapper = new ObjectMapper();
-    
     @JsonProperty("type")
     private String type;
     
@@ -20,6 +18,8 @@ public abstract class GeoJSON {
     }
     
     public String toString() {
+        final ObjectMapper mapper = GeoJSONFactory.getConfig().getMapper();
+
         try {
             return mapper.writeValueAsString(this);
         } catch (JsonGenerationException e) {

--- a/src/main/java/org/wololo/geojson/GeoJSONFactory.java
+++ b/src/main/java/org/wololo/geojson/GeoJSONFactory.java
@@ -10,15 +10,25 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.wololo.geojson.internals.Config;
 
 
 public class GeoJSONFactory {
-    private static final ObjectMapper mapper = new ObjectMapper();
+    private static Config config = new Config();
+
+    public static Config getConfig() {
+        return config;
+    }
+
+    public static void setConfig(Config config) {
+        if (config != null) {
+            GeoJSONFactory.config = config;
+        }
+    }
 
     public static GeoJSON create(String json) {
         try {
-            JsonNode node = mapper.readTree(json);
+            JsonNode node = config.getMapper().readTree(json);
             String type = node.get("type").asText();
             if (type.equals("FeatureCollection")) {
                 return readFeatureCollection(node);
@@ -47,9 +57,9 @@ public class GeoJSONFactory {
     private static Feature readFeature(JsonNode node)
             throws JsonParseException, JsonMappingException, IOException, ClassNotFoundException {
         JsonNode geometryNode = node.get("geometry");
-        JavaType javaType = mapper.getTypeFactory().constructMapType(Map.class, String.class, Object.class);
+        JavaType javaType = config.getMapper().getTypeFactory().constructMapType(Map.class, String.class, Object.class);
         Object id = node.get("id");
-        Map<String, Object> properties = mapper.readValue(node.get("properties").traverse(), javaType);
+        Map<String, Object> properties = config.getMapper().readValue(node.get("properties").traverse(), javaType);
         Geometry geometry = readGeometry(geometryNode);
         return new Feature(id, geometry, properties);
     }
@@ -66,7 +76,7 @@ public class GeoJSONFactory {
 
     private static Geometry readGeometry(JsonNode node, String type)
             throws JsonParseException, JsonMappingException, IOException, ClassNotFoundException {
-        return (Geometry) mapper.readValue(node.traverse(), Class.forName("org.wololo.geojson." + type));
+        return (Geometry) config.getMapper().readValue(node.traverse(), Class.forName("org.wololo.geojson." + type));
     }
 
 }

--- a/src/main/java/org/wololo/geojson/internals/Config.java
+++ b/src/main/java/org/wololo/geojson/internals/Config.java
@@ -1,0 +1,26 @@
+package org.wololo.geojson.internals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * This is a volatile class.
+ * It may be changed if the configuration options change.
+ */
+public final class Config {
+    private final ObjectMapper mapper;
+
+    public Config() {
+        this(new ObjectMapper());
+    }
+
+    public Config(ObjectMapper mapper) {
+        if (mapper == null) {
+            throw new RuntimeException("ObjectMapper instance cannot be null");
+        }
+        this.mapper = mapper;
+    }
+
+    public ObjectMapper getMapper() {
+        return mapper;
+    }
+}


### PR DESCRIPTION
Addresses [issue#22](https://github.com/bjornharrtell/jts2geojson/issues/22)

More direct option would be to allow manipulating the mapper from GeoJSONFactory instead of using a custom Config. However, I decided to add 1 level of custom api over exposing the Jackson internals directly since it was hidden from the entire API thus far.
