### PR TITLE
update JTS to 1.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,9 +59,9 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.vividsolutions</groupId>
+			<groupId>org.locationtech.jts</groupId>
 			<artifactId>jts-core</artifactId>
-			<version>1.14.0</version>
+			<version>1.15.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/org/wololo/jts2geojson/GeoJSONReader.java
+++ b/src/main/java/org/wololo/jts2geojson/GeoJSONReader.java
@@ -2,11 +2,11 @@ package org.wololo.jts2geojson;
 
 import org.wololo.geojson.*;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.LinearRing;
-import com.vividsolutions.jts.geom.PrecisionModel;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.PrecisionModel;
 
 public class GeoJSONReader {
     final static GeometryFactory factory = new GeometryFactory(
@@ -51,7 +51,7 @@ public class GeoJSONReader {
 
     Geometry convert(MultiLineString multiLineString) {
         int size = multiLineString.getCoordinates().length;
-        com.vividsolutions.jts.geom.LineString[] lineStrings = new com.vividsolutions.jts.geom.LineString[size];
+        org.locationtech.jts.geom.LineString[] lineStrings = new org.locationtech.jts.geom.LineString[size];
         for (int i = 0; i < size; i++) {
             lineStrings[i] = factory.createLineString(convert(multiLineString.getCoordinates()[i]));
         }
@@ -62,7 +62,7 @@ public class GeoJSONReader {
         return convertToPolygon(polygon.getCoordinates());
     }
 
-    com.vividsolutions.jts.geom.Polygon convertToPolygon(double[][][] coordinates) {
+    org.locationtech.jts.geom.Polygon convertToPolygon(double[][][] coordinates) {
         LinearRing shell = factory.createLinearRing(convert(coordinates[0]));
 
         if (coordinates.length > 1) {
@@ -79,7 +79,7 @@ public class GeoJSONReader {
 
     Geometry convert(MultiPolygon multiPolygon) {
         int size = multiPolygon.getCoordinates().length;
-        com.vividsolutions.jts.geom.Polygon[] polygons = new com.vividsolutions.jts.geom.Polygon[size];
+        org.locationtech.jts.geom.Polygon[] polygons = new org.locationtech.jts.geom.Polygon[size];
         for (int i = 0; i < size; i++) {
             polygons[i] = convertToPolygon(multiPolygon.getCoordinates()[i]);
         }
@@ -88,7 +88,7 @@ public class GeoJSONReader {
 
     Geometry convert(GeometryCollection gc) {
         int size = gc.getGeometries().length;
-        com.vividsolutions.jts.geom.Geometry[] geometries = new com.vividsolutions.jts.geom.Geometry[size];
+        org.locationtech.jts.geom.Geometry[] geometries = new org.locationtech.jts.geom.Geometry[size];
         for (int i = 0; i < size; i++) {
             geometries[i] = read(gc.getGeometries()[i]);
         }

--- a/src/main/java/org/wololo/jts2geojson/GeoJSONWriter.java
+++ b/src/main/java/org/wololo/jts2geojson/GeoJSONWriter.java
@@ -4,15 +4,15 @@ import java.util.List;
 
 import org.wololo.geojson.Feature;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryCollection;
-import com.vividsolutions.jts.geom.LineString;
-import com.vividsolutions.jts.geom.MultiLineString;
-import com.vividsolutions.jts.geom.MultiPoint;
-import com.vividsolutions.jts.geom.MultiPolygon;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.geom.Polygon;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryCollection;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.MultiLineString;
+import org.locationtech.jts.geom.MultiPoint;
+import org.locationtech.jts.geom.MultiPolygon;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
 
 public class GeoJSONWriter {
 

--- a/src/test/scala/org/wololo/jts2geojson/GeoJSONWriterSpec.scala
+++ b/src/test/scala/org/wololo/jts2geojson/GeoJSONWriterSpec.scala
@@ -1,8 +1,8 @@
 package org.wololo.jts2geojson
 
 import org.scalatest.WordSpec
-import com.vividsolutions.jts.geom.GeometryFactory
-import com.vividsolutions.jts.geom.Coordinate
+import org.locationtech.jts.geom.GeometryFactory
+import org.locationtech.jts.geom.Coordinate
 import org.wololo.geojson.Feature
 import org.wololo.geojson.FeatureCollection
 


### PR DESCRIPTION
JTS is now under the Eclipse Publish and Eclipse Distribution licenses (part of the [LocationTech](https://projects.eclipse.org/projects/locationtech) effort).  This makes distribution much easier.

The package names have switched.

It would be great if we could update to this dependency.

Thanks!