### PR TITLE
 add posibility to use a custom GeometryFactory while reading JTS geometries from GeoJSON

### DIFF
--- a/src/main/java/org/wololo/jts2geojson/GeoJSONReader.java
+++ b/src/main/java/org/wololo/jts2geojson/GeoJSONReader.java
@@ -57,7 +57,7 @@ public class GeoJSONReader {
     }
 
     Geometry convert(MultiPoint multiPoint, GeometryFactory factory) {
-        return factory.createMultiPoint(convert(multiPoint.getCoordinates()));
+        return factory.createMultiPointFromCoords(convert(multiPoint.getCoordinates()));
     }
 
     Geometry convert(LineString lineString, GeometryFactory factory) {

--- a/src/test/scala/org/wololo/jts2geojson/GeoJSONReaderSpec.scala
+++ b/src/test/scala/org/wololo/jts2geojson/GeoJSONReaderSpec.scala
@@ -37,8 +37,8 @@ class GeoJSONReaderSpec extends WordSpec {
       }
 
       "expected result for MultiPoint" in {
-        val expected = factory.createMultiPoint(coordArray)
-        val expectedSrid = factorySrid.createMultiPoint(coordArray)
+        val expected = factory.createMultiPointFromCoords(coordArray)
+        val expectedSrid = factorySrid.createMultiPointFromCoords(coordArray)
         val json = """{"type":"MultiPoint","coordinates":[[1.0,1.0],[1.0,2.0],[2.0,2.0],[1.0,1.0]]}"""
 
         var geometry = reader.read(json)

--- a/src/test/scala/org/wololo/jts2geojson/GeoJSONReaderSpec.scala
+++ b/src/test/scala/org/wololo/jts2geojson/GeoJSONReaderSpec.scala
@@ -1,0 +1,54 @@
+package org.wololo.jts2geojson
+
+import org.locationtech.jts.geom.Coordinate
+import org.locationtech.jts.geom.GeometryFactory
+import org.locationtech.jts.geom.PrecisionModel
+
+import org.scalatest.WordSpec
+
+class GeoJSONReaderSpec extends WordSpec {
+  "GeoJSONReader" when {
+    "reading JTS object from GeoJSON" should {
+
+      val reader = new GeoJSONReader()
+      val writer = new GeoJSONWriter()
+      val factory = new GeometryFactory()
+      val srid = 25832
+      val factorySrid = new GeometryFactory(new PrecisionModel(), srid)
+
+      val coordArray = Array(
+        new Coordinate(1, 1),
+        new Coordinate(1, 2),
+        new Coordinate(2, 2),
+        new Coordinate(1, 1))
+
+      "expected result for Point" in {
+        val expected = factory.createPoint(new Coordinate(1, 1));
+        val expectedSrid = factorySrid.createPoint(new Coordinate(1, 1));
+        val json = """{"type":"Point","coordinates":[1.0,1.0]}"""
+
+        var geometry = reader.read(json)
+        assert(expected === geometry)
+        assert(0 === geometry.getSRID())
+
+        geometry = reader.read(json, factorySrid)
+        assert(expectedSrid === geometry)
+        assert(srid === geometry.getSRID())
+      }
+
+      "expected result for MultiPoint" in {
+        val expected = factory.createMultiPoint(coordArray)
+        val expectedSrid = factorySrid.createMultiPoint(coordArray)
+        val json = """{"type":"MultiPoint","coordinates":[[1.0,1.0],[1.0,2.0],[2.0,2.0],[1.0,1.0]]}"""
+
+        var geometry = reader.read(json)
+        assert(expected === geometry)
+        assert(0 === geometry.getSRID())
+
+        geometry = reader.read(json, factorySrid)
+        assert(expectedSrid === geometry)
+        assert(srid === geometry.getSRID())
+      }
+    }
+  }
+}

--- a/src/test/scala/org/wololo/jts2geojson/GeoJSONWriterSpec.scala
+++ b/src/test/scala/org/wololo/jts2geojson/GeoJSONWriterSpec.scala
@@ -48,7 +48,7 @@ class GeoJSONWriterSpec extends WordSpec {
       }
 
       "expected result for MultiPoint" in {
-        val multiPoint = factory.createMultiPoint(lineString.getCoordinates())
+        val multiPoint = factory.createMultiPointFromCoords(lineString.getCoordinates())
         val json = writer.write(multiPoint)
         assert("""{"type":"MultiPoint","coordinates":[[1.0,1.0],[1.0,2.0],[2.0,2.0],[1.0,1.0]]}""" === json.toString)
       }


### PR DESCRIPTION
I added the methods including shortcuts as discussed in https://github.com/bjornharrtell/jts2geojson/issues/28#issuecomment-429222410 following
Test cases are included for Point and MultiPoint, more are on the way when I have some free time again.
Closes #28 