### PR TITLE
[ObjectMapper.readerFor(Data(g:GeoJSON))] add failing test

### DIFF
--- a/src/test/java/org/wololo/jts2geojson/Data.java
+++ b/src/test/java/org/wololo/jts2geojson/Data.java
@@ -1,0 +1,9 @@
+package org.wololo.jts2geojson;
+
+import org.wololo.geojson.GeoJSON;
+
+class Data {
+
+    public GeoJSON geometry;
+
+}

--- a/src/test/java/org/wololo/jts2geojson/DataFactory.java
+++ b/src/test/java/org/wololo/jts2geojson/DataFactory.java
@@ -1,0 +1,18 @@
+package org.wololo.jts2geojson;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class DataFactory {
+
+    private final static ObjectMapper mapper = new ObjectMapper();
+
+    public static Data fromJson(String json) {
+        try {
+            return mapper.readerFor(Data.class).readValue(json);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/test/scala/org/wololo/jts2geojson/DeserializeGeometryCollectionSpec.scala
+++ b/src/test/scala/org/wololo/jts2geojson/DeserializeGeometryCollectionSpec.scala
@@ -27,6 +27,12 @@ class DeserializeGeometryCollectionSpec extends WordSpec {
           assert(point.getCoordinates.toSeq == Seq(1.1, 2.2))
         }
 
+        "deserialize GeometryCollection successfully if using ObjectMapper" in {
+          val geoJSON = """{ "geometry" : {"type": "GeometryCollection", "geometries": [{"type": "Point",  "coordinates": [1.1, 2.2] }]}}"""
+          val value = DataFactory.fromJson(geoJSON)
+          assert(value.isInstanceOf[Data])
+        }
+
       }
 
     }


### PR DESCRIPTION
Hi @bjornharrtell. This time the PR contains essence of the problem. I hope you'll understand what's worng now. Thank you for your time and your library. 

java.lang.RuntimeException: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of `org.wololo.geojson.GeoJSON`