### PR TITLE
Replace vulnerable jackson-databind

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>2.13.2</version>
+			<version>2.13.2.2</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
jackson-databind 2.13.2 has the CVE-2020-36518 which is fixed in 2.13.2.1 and newer.

To avoid integration issues, instead of replacing with 2.14, I suggest to use the same minor version including the fix of the CVE.