### PR TITLE
added handling of missing geometry attribute

### DIFF
--- a/src/main/java/org/wololo/geojson/GeoJSONFactory.java
+++ b/src/main/java/org/wololo/geojson/GeoJSONFactory.java
@@ -48,7 +48,7 @@ public class GeoJSONFactory {
 
     private static Geometry readGeometry(JsonNode node)
             throws JsonParseException, JsonMappingException, IOException, ClassNotFoundException {
-        if (!node.isNull())
+        if (node != null && !node.isNull())
             return readGeometry(node, node.get("type").asText());
         else
             return null;

--- a/src/test/scala/org/wololo/jts2geojson/GeoJSONFactorySpec.scala
+++ b/src/test/scala/org/wololo/jts2geojson/GeoJSONFactorySpec.scala
@@ -6,6 +6,16 @@ import java.util.HashMap
 
 class GeoJSONFactorySpec extends AnyWordSpec {
     "GeoJSONFactory" when {
+      "dealing with badly encoded file" should {
+        "read missing geometry field as null" in {
+          val json = """{"type":"Feature","properties":{"test":1}}"""
+          val expected = """{"type":"Feature","geometry":null,"properties":{"test":1}}"""
+
+          val geojson = GeoJSONFactory.create(json)
+          assert(geojson.toString == expected)
+        }
+      }
+
       "parsing GeoJSON to object" should {
         val geometry = new Point(Array(1, 1))
         val properties = new HashMap[String, Object]()


### PR DESCRIPTION
GeoJSON spec allows `"geometry": null` but [I encountered file](https://github.com/spatialx-project/docker-spark-geolake/issues/3) where the author just skipped `geometry` attribute altogether.

Jackson parses that to node = null. Current check expects node object with method isNull so it throws NullPointerException.

I think that should be handled gracefully by just assuming missing geometry == geometry: null even though that's not covered by the spec.